### PR TITLE
don't panic when a service validate method fails at startup

### DIFF
--- a/tests/test_greenlets_mgr.py
+++ b/tests/test_greenlets_mgr.py
@@ -43,9 +43,11 @@ class TestGreenletsMgr(unittest.TestCase):
 
     def test_stop(self):
         mgr = GreenletsMgr()
-        mgr.add("foo", gevent.spawn(self.foo))
+        gl = gevent.spawn(self.foo)
+        mgr.add("foo", gl)
         mgr.stop('foo')
-        gl = mgr.get('foo')
+        with self.assertRaises(KeyError):
+            gl = mgr.get('foo')
         self.assertFalse(gl.started)
         self.assertTrue(gl.ready())
 

--- a/zerorobot/template/base.py
+++ b/zerorobot/template/base.py
@@ -79,6 +79,7 @@ class GreenletsMgr:
         try:
             gl = self.get(key)
             gl.kill()
+            del self.gls[key]
         except KeyError:
             pass
 


### PR DESCRIPTION
- instead of letting the robot panic, we keep a list of service that
failed to execute their validate method and try to re-execute it later

fixes #91